### PR TITLE
added delete to line items

### DIFF
--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -77,6 +77,7 @@ class LineItems(ViewSet):
         try:
             customer = Customer.objects.get(user=request.auth.user)
             order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
+            order_product.delete()
 
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
Customers are complaining that they can't remove an item from the cart after it has been added.

## Changes

- added actual delete to Destroy function in views/lineitem.py

## Requests / Responses

**Request**

DELETE `/lineitem/{id}` deletes a line item

**Response**

HTTP/1.1 204 no content

```json
{ }
```

## Testing

DELETE `/lineitem/{id}`  deletes the line item


## Related Issues

- Fixes #5 